### PR TITLE
feat: auth 폴더 및 signup, signin 구조 구현 (#13)

### DIFF
--- a/apps/web/app/auth/layout.tsx
+++ b/apps/web/app/auth/layout.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/auth/signin/page.tsx
+++ b/apps/web/app/auth/signin/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+import PageTitle from '@repo/ui/components/typography/PageTitle';
+
+export default function SigninPage() {
+  const handleSocialSignin = (provider: string) => {
+    // 소셜 로그인 로직
+  };
+
+  return (
+    <>
+      <PageTitle>로그인</PageTitle>
+      <div className="flex flex-col">
+        <button onClick={() => handleSocialSignin("google")}>Google로 로그인</button>
+        <button onClick={() => handleSocialSignin("kakao")}>Kakao로 로그인</button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/auth/signup/page.tsx
+++ b/apps/web/app/auth/signup/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+import PageTitle from '@repo/ui/components/typography/PageTitle';
+
+export default function SignupPage() {
+  const handleSocialSignup = (provider: string) => {
+    // 소셜 회원가입 로직
+  };
+
+  return (
+    <>
+      <PageTitle>회원가입</PageTitle>
+      <div className="flex flex-col">
+        <button onClick={() => handleSocialSignup("google")}>Google로 회원가입</button>
+        <button onClick={() => handleSocialSignup("kakao")}>Kakao로 회원가입</button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈

auth 폴더 및 signup, signin 구조 구현

## Task TODOLIST

- [x] auth 폴더 생성

- [x] signup 폴더 및 page.tsx 생성

- [x] signin 폴더 및 page.tsx 생성

## ✨ 개발 내용

- /app/auth 하위에 signup, signin 폴더 및 page.tsx 생성
- 각 signup/, signin/ 폴더에는 page.tsx만 1차 생성


