### PR TITLE
[bugFix] - 경매 등록 버튼 클릭시 경매 등록이 불가능한 유저도 경매 등록이 가능한 문제 수정

### DIFF
--- a/apps/web/src/entities/auction/supabase.ts
+++ b/apps/web/src/entities/auction/supabase.ts
@@ -180,6 +180,7 @@ export const selectAuctionCardList = async (order: string | null, keyword: strin
   `
     )
     .order(order, { ascending })
+    .order('auction_id', { ascending: true })
     .eq('status', 'OPEN')
     .ilike('title', `%${keyword}%`)
     .range(page, page + ITEM_PER_PAGE - 1);

--- a/apps/web/src/features/auction/form/components/AuctionForm.tsx
+++ b/apps/web/src/features/auction/form/components/AuctionForm.tsx
@@ -33,10 +33,11 @@ import type { AuctionFormProps, AuctionFormType, PreviewImage } from 'src/entiti
 const AuctionForm = ({ auctionIdParam, loggedInUserId }: AuctionFormProps) => {
   const isEditing: boolean = !!auctionIdParam;
   const [isFormLoading, setIsFormLoading] = useState<boolean>(isEditing);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [previewImages, setPreviewImages] = useState<PreviewImage[]>([]);
   const [imageUrlsToDelete, setImageUrlsToDelete] = useState<string[]>([]);
-  const router = useRouter(); //TODO - push로 구조 분해 할당하기
+  const { push } = useRouter();
 
   console.log('로그인한 유저 id', loggedInUserId);
   console.log('auctionIdParam', auctionIdParam);
@@ -111,6 +112,7 @@ const AuctionForm = ({ auctionIdParam, loggedInUserId }: AuctionFormProps) => {
   }, [fetchedAuction, isEditing, form, isFormLoading]);
 
   const onSubmit = async (values: AuctionFormType) => {
+    setIsSubmitting(true);
     const { title, description, endDay, endTime, startingPoint, maxPoint } = values;
 
     const korEndDate = setTimeToDate(endDay, endTime);
@@ -157,8 +159,7 @@ const AuctionForm = ({ auctionIdParam, loggedInUserId }: AuctionFormProps) => {
         console.log('결과', data);
         console.log('옥션아이디', data.auction_id);
 
-        //FIXME - 테스트 끝나면 주석 제거하기 (KMH)
-        // router.push(`/auctions/${data.auction_id}`);
+        push(`/auctions/${data.auction_id}`);
         return;
       } catch (error) {
         popToast('error', '경매 등록 에러', '경매 등록에 실패했습니다.', 'long');
@@ -192,8 +193,8 @@ const AuctionForm = ({ auctionIdParam, loggedInUserId }: AuctionFormProps) => {
     console.log('결과', data);
     console.log('옥션아이디', data.auction_id);
 
-    //FIXME - 테스트 끝나면 주석 제거하기 (KMH)
-    // router.push(`/auctions/${data.auction_id}`);
+    push(`/auctions/${data.auction_id}`);
+    setIsSubmitting(false);
   };
 
   //TODO - error가 발생하면 대처가 불가능, 화면을 어떡해 보여줄지 의논하기 (KMH)
@@ -257,12 +258,7 @@ const AuctionForm = ({ auctionIdParam, loggedInUserId }: AuctionFormProps) => {
               setPreviewImages={setPreviewImages}
               setImageUrlsToDelete={setImageUrlsToDelete}
             />
-            <Button
-              type="submit"
-              className="h-12 w-full"
-              variant="base"
-              disabled={isPostAuctionPending || isPatchAuctionPending}
-            >
+            <Button type="submit" className="h-12 w-full" variant="base" disabled={isSubmitting}>
               {(isEditing && !isPatchAuctionPending && '수정하기') ||
                 (isEditing && isPatchAuctionPending && '수정중...') ||
                 (!isEditing && !isPostAuctionPending && '등록하기') ||

--- a/apps/web/src/features/auction/form/page/AuctionFormPage.tsx
+++ b/apps/web/src/features/auction/form/page/AuctionFormPage.tsx
@@ -14,6 +14,7 @@ const AuctionFormPage = async ({ auctionId }: AuctionFormPageProps) => {
   const userInfo = await getServerUser();
   const loggedInUserId = userInfo!.id; //NOTE - 미들웨어에서 비로그인시 메인 페이지로 리다이렉트 함
   const queryClient = new QueryClient();
+  //TODO - 유저 주소는 userInfo에서 가져오도록 수정하기 (KMH)
 
   //TODO - 마이 페이지에서 주소를 변경할 때, 아래 쿼리 키의 캐시를 지워야 함 (KMH)
   await prefetchAddressId(loggedInUserId, queryClient);

--- a/apps/web/src/features/auction/list/components/AuctionList.tsx
+++ b/apps/web/src/features/auction/list/components/AuctionList.tsx
@@ -4,7 +4,9 @@ import { useEffect } from 'react';
 import { Skeleton } from '@repo/ui/components/ui/skeleton';
 import { AUCTION_LIST_SKELETON_LENGTH } from 'src/entities/auction/constants';
 import { useGetAuctionListQuery } from 'src/entities/auction/queries/auction';
+import { useUserState } from 'src/entities/auth/stores/useAuthStore';
 import AuctionCard from 'src/features/auction/shared/AuctionCard';
+import WriteAuctionButton from 'src/features/auction/WriteAuctionButton';
 import { LoadingSpinner } from 'src/shared/ui/LoadingSpinner';
 import { v4 as uuidv4 } from 'uuid';
 import type { AuctionListProps, EpisodeCount } from 'src/entities/auction/types';
@@ -12,6 +14,10 @@ import type { AuctionRow } from 'src/shared/supabase/types';
 
 const AuctionList = ({ order, keyword }: AuctionListProps) => {
   console.log('list', order, keyword);
+
+  const user = useUserState();
+  const userAddressId = user?.address_id;
+
   //TODO - nextjs 캐시로 관리하기 (KMH)
   const { fetchedAuctions, isError, error, isPending, isFetchingNextPage, fetchNextPage, ref, inView } =
     useGetAuctionListQuery(order, keyword);
@@ -69,6 +75,7 @@ const AuctionList = ({ order, keyword }: AuctionListProps) => {
       <div className="flex w-full justify-center" ref={ref}>
         {isFetchingNextPage && <LoadingSpinner />}
       </div>
+      {userAddressId && <WriteAuctionButton />}
     </>
   );
 };

--- a/apps/web/src/features/auction/list/components/AuctionList.tsx
+++ b/apps/web/src/features/auction/list/components/AuctionList.tsx
@@ -28,7 +28,7 @@ const AuctionList = ({ order, keyword }: AuctionListProps) => {
     console.error(error);
     return <p>에러 발생</p>;
   }
-
+  //TODO - 총 경매 갯수도 총 경매의 갯수로 수정하기 (KMH)
   return (
     <>
       <h3 className="pb-2 pt-1 text-sm">

--- a/apps/web/src/features/auction/list/components/AuctionList.tsx
+++ b/apps/web/src/features/auction/list/components/AuctionList.tsx
@@ -4,9 +4,7 @@ import { useEffect } from 'react';
 import { Skeleton } from '@repo/ui/components/ui/skeleton';
 import { AUCTION_LIST_SKELETON_LENGTH } from 'src/entities/auction/constants';
 import { useGetAuctionListQuery } from 'src/entities/auction/queries/auction';
-import { useUserState } from 'src/entities/auth/stores/useAuthStore';
 import AuctionCard from 'src/features/auction/shared/AuctionCard';
-import WriteAuctionButton from 'src/features/auction/WriteAuctionButton';
 import { LoadingSpinner } from 'src/shared/ui/LoadingSpinner';
 import { v4 as uuidv4 } from 'uuid';
 import type { AuctionListProps, EpisodeCount } from 'src/entities/auction/types';
@@ -14,9 +12,6 @@ import type { AuctionRow } from 'src/shared/supabase/types';
 
 const AuctionList = ({ order, keyword }: AuctionListProps) => {
   console.log('list', order, keyword);
-
-  const user = useUserState();
-  const userAddressId = user?.address_id;
 
   //TODO - nextjs 캐시로 관리하기 (KMH)
   const { fetchedAuctions, isError, error, isPending, isFetchingNextPage, fetchNextPage, ref, inView } =
@@ -75,7 +70,6 @@ const AuctionList = ({ order, keyword }: AuctionListProps) => {
       <div className="flex w-full justify-center" ref={ref}>
         {isFetchingNextPage && <LoadingSpinner />}
       </div>
-      {userAddressId && <WriteAuctionButton />}
     </>
   );
 };

--- a/apps/web/src/features/auction/list/page/AuctionListPage.tsx
+++ b/apps/web/src/features/auction/list/page/AuctionListPage.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import { prefetchedAuctionList } from 'src/entities/auction/queries/auction';
 import AuctionList from 'src/features/auction/list/components/AuctionList';
 import SelectOrder from 'src/features/auction/list/components/SelectOrder';
+import WriteAuctionButton from 'src/features/auction/WriteAuctionButton';
 import PageContainer from 'src/shared/ui/PageContainer';
 import PageTitle from 'src/shared/ui/PageTitle';
 import GoTopButton from 'src/shared/utils/goTopButton';
@@ -21,6 +22,7 @@ const AuctionListPage = async ({ order, keyword }: AuctionListPageProps) => {
       <HydrationBoundary state={dehydrate(queryClient)}>
         <AuctionList order={order} keyword={keyword} />
       </HydrationBoundary>
+      <WriteAuctionButton />
       <GoTopButton />
     </PageContainer>
   );

--- a/apps/web/src/features/auction/list/page/AuctionListPage.tsx
+++ b/apps/web/src/features/auction/list/page/AuctionListPage.tsx
@@ -2,7 +2,6 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import { prefetchedAuctionList } from 'src/entities/auction/queries/auction';
 import AuctionList from 'src/features/auction/list/components/AuctionList';
 import SelectOrder from 'src/features/auction/list/components/SelectOrder';
-import WriteAuctionButton from 'src/features/auction/WriteAuctionButton';
 import PageContainer from 'src/shared/ui/PageContainer';
 import PageTitle from 'src/shared/ui/PageTitle';
 import GoTopButton from 'src/shared/utils/goTopButton';
@@ -22,7 +21,6 @@ const AuctionListPage = async ({ order, keyword }: AuctionListPageProps) => {
       <HydrationBoundary state={dehydrate(queryClient)}>
         <AuctionList order={order} keyword={keyword} />
       </HydrationBoundary>
-      <WriteAuctionButton />
       <GoTopButton />
     </PageContainer>
   );

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -32,7 +32,7 @@ export const middleware = async (request: NextRequest) => {
         if (authorId !== userInfo.id) {
           return NextResponse.redirect(new URL('/main', request.url));
         }
-      } catch (error) {
+      } catch {
         return NextResponse.redirect(new URL('/main', request.url));
       }
     }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -30,13 +30,15 @@ export const middleware = async (request: NextRequest) => {
       const user = await getServerUserWithProfile();
       const userAddressId = user.address_id;
       const userRole = user.role;
-      console.log('userRole', userRole);
+
       if (!userAddressId) {
-        return NextResponse.redirect(new URL('/main', request.url)); //TODO - 마이 페이지 주소 등록으로 이동시키도록 수정하기 (KMH)
+        return NextResponse.redirect(new URL('/main', request.url));
+        //TODO - 마이 페이지 주소 등록으로 이동시키도록 수정하기 (KMH)
       }
 
       if (userRole === 'buyer') {
         return NextResponse.redirect(new URL('/main', request.url));
+        //TODO - 마이 페이지로 가는 것이 어떤지 물어보기, 그리고 아무 말없이 리다이렉트 시키는게 UX상 문제있는 것 같음 (KMH)
       }
     } catch {
       return NextResponse.redirect(new URL('/main', request.url));

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -31,9 +31,10 @@ export const middleware = async (request: NextRequest) => {
       const userAddressId = user.address_id;
       const userRole = user.role;
 
+      console.log('userAddress', userAddressId);
+
       if (!userAddressId) {
-        return NextResponse.redirect(new URL('/main', request.url));
-        //TODO - 마이 페이지 주소 등록으로 이동시키도록 수정하기 (KMH)
+        return NextResponse.redirect(new URL('/mypage/addresses/write', request.url));
       }
 
       if (userRole === 'buyer') {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { selectUserIdByAuctionId } from 'src/entities/auction/serverActions';
-import { getServerUser } from 'src/entities/auth/serverAction';
+import { getServerUser, getServerUserWithProfile } from 'src/entities/auth/serverAction';
 import type { NextRequest } from 'next/server';
 
 export const middleware = async (request: NextRequest) => {
@@ -25,7 +25,19 @@ export const middleware = async (request: NextRequest) => {
   // 경매 수정 권한 체크
   if (pathName === '/auctions/write') {
     //NOTE - 경매 등록/수정 페이지에서 로그인되어 있지 않으면 로그인 페이지로 이동
+
+    try {
+      const user = await getServerUserWithProfile();
+      const userAddressId = user.address_id;
+      if (!userAddressId) {
+        return NextResponse.redirect(new URL('/main', request.url)); //TODO - 마이 페이지 주소 등록으로 이동시키도록 수정하기 (KMH)
+      }
+    } catch {
+      return NextResponse.redirect(new URL('/main', request.url));
+    }
+
     const auctionId = searchParams.get('auction_id')?.trim();
+
     if (auctionId) {
       try {
         const authorId: string = await selectUserIdByAuctionId(auctionId);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -27,7 +27,7 @@ export const middleware = async (request: NextRequest) => {
     //NOTE - 경매 등록/수정 페이지에서 로그인되어 있지 않으면 로그인 페이지로 이동
 
     try {
-      const user = await getServerUserWithProfile();
+      const user = await getServerUserWithProfile(); //TODO - getServerUser와 비교해서 위를 WithProfile로 바꾸기 (KMH)
       const userAddressId = user.address_id;
       const userRole = user.role;
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -29,8 +29,14 @@ export const middleware = async (request: NextRequest) => {
     try {
       const user = await getServerUserWithProfile();
       const userAddressId = user.address_id;
+      const userRole = user.role;
+      console.log('userRole', userRole);
       if (!userAddressId) {
         return NextResponse.redirect(new URL('/main', request.url)); //TODO - 마이 페이지 주소 등록으로 이동시키도록 수정하기 (KMH)
+      }
+
+      if (userRole === 'buyer') {
+        return NextResponse.redirect(new URL('/main', request.url));
       }
     } catch {
       return NextResponse.redirect(new URL('/main', request.url));

--- a/apps/web/src/shared/supabase/types/supabase.ts
+++ b/apps/web/src/shared/supabase/types/supabase.ts
@@ -1,757 +1,740 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   // Allows to automatically instanciate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "12.2.3 (519615d)"
-  }
+    PostgrestVersion: '12.2.3 (519615d)';
+  };
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          operationName?: string
-          query?: string
-          variables?: Json
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+          extensions?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       addresses: {
         Row: {
-          address_id: string
-          business_name: string
-          company_image: string | null
-          created_at: string
-          detail_address: string | null
-          is_default: boolean
-          postal_code: string
-          road_address: string
-          user_id: string | null
-        }
+          address_id: string;
+          business_name: string;
+          company_image: string | null;
+          created_at: string;
+          detail_address: string | null;
+          is_default: boolean;
+          postal_code: string;
+          road_address: string;
+          user_id: string | null;
+        };
         Insert: {
-          address_id?: string
-          business_name: string
-          company_image?: string | null
-          created_at?: string
-          detail_address?: string | null
-          is_default: boolean
-          postal_code: string
-          road_address: string
-          user_id?: string | null
-        }
+          address_id?: string;
+          business_name: string;
+          company_image?: string | null;
+          created_at?: string;
+          detail_address?: string | null;
+          is_default: boolean;
+          postal_code: string;
+          road_address: string;
+          user_id?: string | null;
+        };
         Update: {
-          address_id?: string
-          business_name?: string
-          company_image?: string | null
-          created_at?: string
-          detail_address?: string | null
-          is_default?: boolean
-          postal_code?: string
-          road_address?: string
-          user_id?: string | null
-        }
+          address_id?: string;
+          business_name?: string;
+          company_image?: string | null;
+          created_at?: string;
+          detail_address?: string | null;
+          is_default?: boolean;
+          postal_code?: string;
+          road_address?: string;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'addresses_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       auctions: {
         Row: {
-          address_id: string
-          auction_id: string
-          created_at: string
-          current_point: number
-          description: string
-          end_date: string
-          favorites: string[]
-          highest_bidder_id: string | null
-          image_urls: string[]
-          max_point: number
-          starting_point: number
-          status: string
-          title: string
-          updated_at: string | null
-          user_id: string
-        }
+          address_id: string;
+          auction_id: string;
+          created_at: string;
+          current_point: number;
+          description: string;
+          end_date: string;
+          favorites: string[];
+          highest_bidder_id: string | null;
+          image_urls: string[];
+          max_point: number;
+          starting_point: number;
+          status: string;
+          title: string;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          address_id: string
-          auction_id?: string
-          created_at?: string
-          current_point?: number
-          description: string
-          end_date?: string
-          favorites?: string[]
-          highest_bidder_id?: string | null
-          image_urls?: string[]
-          max_point: number
-          starting_point: number
-          status?: string
-          title: string
-          updated_at?: string | null
-          user_id?: string
-        }
+          address_id: string;
+          auction_id?: string;
+          created_at?: string;
+          current_point?: number;
+          description: string;
+          end_date?: string;
+          favorites?: string[];
+          highest_bidder_id?: string | null;
+          image_urls?: string[];
+          max_point: number;
+          starting_point: number;
+          status?: string;
+          title: string;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Update: {
-          address_id?: string
-          auction_id?: string
-          created_at?: string
-          current_point?: number
-          description?: string
-          end_date?: string
-          favorites?: string[]
-          highest_bidder_id?: string | null
-          image_urls?: string[]
-          max_point?: number
-          starting_point?: number
-          status?: string
-          title?: string
-          updated_at?: string | null
-          user_id?: string
-        }
+          address_id?: string;
+          auction_id?: string;
+          created_at?: string;
+          current_point?: number;
+          description?: string;
+          end_date?: string;
+          favorites?: string[];
+          highest_bidder_id?: string | null;
+          image_urls?: string[];
+          max_point?: number;
+          starting_point?: number;
+          status?: string;
+          title?: string;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "auctions_address_id_fkey"
-            columns: ["address_id"]
-            isOneToOne: false
-            referencedRelation: "addresses"
-            referencedColumns: ["address_id"]
+            foreignKeyName: 'auctions_address_id_fkey';
+            columns: ['address_id'];
+            isOneToOne: false;
+            referencedRelation: 'addresses';
+            referencedColumns: ['address_id'];
           },
           {
-            foreignKeyName: "auctions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'auctions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       chat_rooms: {
         Row: {
-          auction_id: string | null
-          buyer_id: string | null
-          created_at: string | null
-          id: string
-          seller_id: string | null
-          updated_at: string | null
-        }
+          auction_id: string | null;
+          buyer_id: string | null;
+          created_at: string | null;
+          id: string;
+          seller_id: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          auction_id?: string | null
-          buyer_id?: string | null
-          created_at?: string | null
-          id?: string
-          seller_id?: string | null
-          updated_at?: string | null
-        }
+          auction_id?: string | null;
+          buyer_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          seller_id?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          auction_id?: string | null
-          buyer_id?: string | null
-          created_at?: string | null
-          id?: string
-          seller_id?: string | null
-          updated_at?: string | null
-        }
+          auction_id?: string | null;
+          buyer_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          seller_id?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "chat_rooms_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'chat_rooms_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "chat_rooms_buyer_id_fkey"
-            columns: ["buyer_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'chat_rooms_buyer_id_fkey';
+            columns: ['buyer_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "chat_rooms_seller_id_fkey"
-            columns: ["seller_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'chat_rooms_seller_id_fkey';
+            columns: ['seller_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       episodes: {
         Row: {
-          auction_id: string | null
-          bid_date: string | null
-          bid_point: number | null
-          created_at: string
-          description: string
-          episode_id: string
-          likes: string[]
-          title: string
-          updated_at: string | null
-          user_id: string | null
-          winning_bid: boolean | null
-        }
+          auction_id: string | null;
+          bid_date: string | null;
+          bid_point: number | null;
+          created_at: string;
+          description: string;
+          episode_id: string;
+          likes: string[];
+          title: string;
+          updated_at: string | null;
+          user_id: string | null;
+          winning_bid: boolean | null;
+        };
         Insert: {
-          auction_id?: string | null
-          bid_date?: string | null
-          bid_point?: number | null
-          created_at?: string
-          description: string
-          episode_id?: string
-          likes?: string[]
-          title: string
-          updated_at?: string | null
-          user_id?: string | null
-          winning_bid?: boolean | null
-        }
+          auction_id?: string | null;
+          bid_date?: string | null;
+          bid_point?: number | null;
+          created_at?: string;
+          description: string;
+          episode_id?: string;
+          likes?: string[];
+          title: string;
+          updated_at?: string | null;
+          user_id?: string | null;
+          winning_bid?: boolean | null;
+        };
         Update: {
-          auction_id?: string | null
-          bid_date?: string | null
-          bid_point?: number | null
-          created_at?: string
-          description?: string
-          episode_id?: string
-          likes?: string[]
-          title?: string
-          updated_at?: string | null
-          user_id?: string | null
-          winning_bid?: boolean | null
-        }
+          auction_id?: string | null;
+          bid_date?: string | null;
+          bid_point?: number | null;
+          created_at?: string;
+          description?: string;
+          episode_id?: string;
+          likes?: string[];
+          title?: string;
+          updated_at?: string | null;
+          user_id?: string | null;
+          winning_bid?: boolean | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "episodes_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'episodes_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "episodes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'episodes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       inquiries: {
         Row: {
-          auction_id: string
-          created_at: string
-          description: string
-          inquiry_id: string
-          title: string
-          updated_at: string | null
-          user_id: string
-        }
+          auction_id: string;
+          created_at: string;
+          description: string;
+          inquiry_id: string;
+          title: string;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          auction_id: string
-          created_at?: string
-          description: string
-          inquiry_id?: string
-          title: string
-          updated_at?: string | null
-          user_id: string
-        }
+          auction_id: string;
+          created_at?: string;
+          description: string;
+          inquiry_id?: string;
+          title: string;
+          updated_at?: string | null;
+          user_id: string;
+        };
         Update: {
-          auction_id?: string
-          created_at?: string
-          description?: string
-          inquiry_id?: string
-          title?: string
-          updated_at?: string | null
-          user_id?: string
-        }
+          auction_id?: string;
+          created_at?: string;
+          description?: string;
+          inquiry_id?: string;
+          title?: string;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "inquiry_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'inquiry_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "inquiry_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'inquiry_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       keywords: {
         Row: {
-          count: number
-          keyword: string
-          keyword_id: number
-          updated_at: string
-        }
+          count: number;
+          keyword: string;
+          keyword_id: number;
+          updated_at: string;
+        };
         Insert: {
-          count?: number
-          keyword: string
-          keyword_id?: number
-          updated_at?: string
-        }
+          count?: number;
+          keyword: string;
+          keyword_id?: number;
+          updated_at?: string;
+        };
         Update: {
-          count?: number
-          keyword?: string
-          keyword_id?: number
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          count?: number;
+          keyword?: string;
+          keyword_id?: number;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       messages: {
         Row: {
-          chat_room_id: string | null
-          content: string
-          created_at: string | null
-          id: string
-          is_read: boolean | null
-          read_at: string | null
-          sender_id: string | null
-        }
+          chat_room_id: string | null;
+          content: string;
+          created_at: string | null;
+          id: string;
+          is_read: boolean | null;
+          read_at: string | null;
+          sender_id: string | null;
+        };
         Insert: {
-          chat_room_id?: string | null
-          content: string
-          created_at?: string | null
-          id?: string
-          is_read?: boolean | null
-          read_at?: string | null
-          sender_id?: string | null
-        }
+          chat_room_id?: string | null;
+          content: string;
+          created_at?: string | null;
+          id?: string;
+          is_read?: boolean | null;
+          read_at?: string | null;
+          sender_id?: string | null;
+        };
         Update: {
-          chat_room_id?: string | null
-          content?: string
-          created_at?: string | null
-          id?: string
-          is_read?: boolean | null
-          read_at?: string | null
-          sender_id?: string | null
-        }
+          chat_room_id?: string | null;
+          content?: string;
+          created_at?: string | null;
+          id?: string;
+          is_read?: boolean | null;
+          read_at?: string | null;
+          sender_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "messages_chat_room_id_fkey"
-            columns: ["chat_room_id"]
-            isOneToOne: false
-            referencedRelation: "chat_rooms"
-            referencedColumns: ["id"]
+            foreignKeyName: 'messages_chat_room_id_fkey';
+            columns: ['chat_room_id'];
+            isOneToOne: false;
+            referencedRelation: 'chat_rooms';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "messages_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       points: {
         Row: {
-          amount: number
-          balance_after: number
-          created_at: string
-          description: string
-          point_id: string
-          source: string
-          type: string
-          user_id: string
-        }
+          amount: number;
+          balance_after: number;
+          created_at: string;
+          description: string;
+          point_id: string;
+          source: string;
+          type: string;
+          user_id: string;
+        };
         Insert: {
-          amount: number
-          balance_after: number
-          created_at?: string
-          description: string
-          point_id?: string
-          source: string
-          type: string
-          user_id: string
-        }
+          amount: number;
+          balance_after: number;
+          created_at?: string;
+          description: string;
+          point_id?: string;
+          source: string;
+          type: string;
+          user_id: string;
+        };
         Update: {
-          amount?: number
-          balance_after?: number
-          created_at?: string
-          description?: string
-          point_id?: string
-          source?: string
-          type?: string
-          user_id?: string
-        }
+          amount?: number;
+          balance_after?: number;
+          created_at?: string;
+          description?: string;
+          point_id?: string;
+          source?: string;
+          type?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "points_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'points_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       ranking: {
         Row: {
-          auction_id: string
-          bid_amount: number
-          created_at: string
-          id: string
-          rank_position: number
-          updated_at: string
-          user_id: string
-        }
+          auction_id: string;
+          bid_amount: number;
+          created_at: string;
+          id: string;
+          rank_position: number;
+          updated_at: string;
+          user_id: string;
+        };
         Insert: {
-          auction_id: string
-          bid_amount: number
-          created_at?: string
-          id?: string
-          rank_position: number
-          updated_at?: string
-          user_id: string
-        }
+          auction_id: string;
+          bid_amount: number;
+          created_at?: string;
+          id?: string;
+          rank_position: number;
+          updated_at?: string;
+          user_id: string;
+        };
         Update: {
-          auction_id?: string
-          bid_amount?: number
-          created_at?: string
-          id?: string
-          rank_position?: number
-          updated_at?: string
-          user_id?: string
-        }
+          auction_id?: string;
+          bid_amount?: number;
+          created_at?: string;
+          id?: string;
+          rank_position?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "ranking_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'ranking_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "ranking_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'ranking_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       users: {
         Row: {
-          address_id: string | null
-          created_at: string
-          email: string
-          id: string
-          nick_name: string
-          point: number
-          role: string
-          user_avatar: string | null
-        }
+          address_id: string | null;
+          created_at: string;
+          email: string;
+          id: string;
+          nick_name: string;
+          point: number;
+          role: string;
+          user_avatar: string | null;
+        };
         Insert: {
-          address_id?: string | null
-          created_at?: string
-          email: string
-          id?: string
-          nick_name: string
-          point?: number
-          role: string
-          user_avatar?: string | null
-        }
+          address_id?: string | null;
+          created_at?: string;
+          email: string;
+          id?: string;
+          nick_name: string;
+          point?: number;
+          role: string;
+          user_avatar?: string | null;
+        };
         Update: {
-          address_id?: string | null
-          created_at?: string
-          email?: string
-          id?: string
-          nick_name?: string
-          point?: number
-          role?: string
-          user_avatar?: string | null
-        }
+          address_id?: string | null;
+          created_at?: string;
+          email?: string;
+          id?: string;
+          nick_name?: string;
+          point?: number;
+          role?: string;
+          user_avatar?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "users_address_id_fkey"
-            columns: ["address_id"]
-            isOneToOne: false
-            referencedRelation: "addresses"
-            referencedColumns: ["address_id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: 'users_address_id_fkey';
+            columns: ['address_id'];
+            isOneToOne: false;
+            referencedRelation: 'addresses';
+            referencedColumns: ['address_id'];
+          }
+        ];
+      };
+    };
     Views: {
       user_bid_totals: {
         Row: {
-          auction_id: string | null
-          episode_id: string | null
-          total_bid_points: number | null
-          user_id: string | null
-        }
+          auction_id: string | null;
+          episode_id: string | null;
+          total_bid_points: number | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "episodes_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'episodes_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "points_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: 'points_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       valid_user_bid_totals: {
         Row: {
-          auction_id: string | null
-          total_bid_points: number | null
-          user_id: string | null
-        }
+          auction_id: string | null;
+          total_bid_points: number | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "episodes_auction_id_fkey"
-            columns: ["auction_id"]
-            isOneToOne: false
-            referencedRelation: "auctions"
-            referencedColumns: ["auction_id"]
+            foreignKeyName: 'episodes_auction_id_fkey';
+            columns: ['auction_id'];
+            isOneToOne: false;
+            referencedRelation: 'auctions';
+            referencedColumns: ['auction_id'];
           },
           {
-            foreignKeyName: "episodes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: 'episodes_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+    };
     Functions: {
       get_auction_detail_with_address: {
-        Args: { auction_id_param: string }
+        Args: { auction_id_param: string };
         Returns: {
-          auction_id: string
-          user_id: string
-          title: string
-          description: string
-          current_point: number
-          max_point: number
-          image_urls: string[]
-          end_date: string
-          favorites: string[]
-          status: string
-          address_id: string
-          business_name: string
-          postal_code: string
-          road_address: string
-          detail_address: string
-          company_image: string
-        }[]
-      }
+          auction_id: string;
+          user_id: string;
+          title: string;
+          description: string;
+          current_point: number;
+          max_point: number;
+          image_urls: string[];
+          end_date: string;
+          favorites: string[];
+          status: string;
+          address_id: string;
+          business_name: string;
+          postal_code: string;
+          road_address: string;
+          detail_address: string;
+          company_image: string;
+        }[];
+      };
       get_auction_details: {
-        Args:
-          | { auction_id: string }
-          | { auction_id_param: string }
-          | { user_id: number }
+        Args: { auction_id: string } | { auction_id_param: string } | { user_id: number };
         Returns: {
-          title: string
-          description: string
-          starting_point: number
-          max_point: number
-          image_urls: string[]
-          end_date: string
-          business_name: string
-          postal_code: string
-          road_address: string
-          detail_address: string
-        }[]
-      }
+          title: string;
+          description: string;
+          starting_point: number;
+          max_point: number;
+          image_urls: string[];
+          end_date: string;
+          business_name: string;
+          postal_code: string;
+          road_address: string;
+          detail_address: string;
+        }[];
+      };
       get_auction_form: {
-        Args: { auction_id_param: string }
+        Args: { auction_id_param: string };
         Returns: {
-          title: string
-          description: string
-          starting_point: number
-          max_point: number
-          image_urls: string[]
-          end_date: string
-          address_id: string
-          business_name: string
-          postal_code: string
-          road_address: string
-          detail_address: string
-        }[]
-      }
+          title: string;
+          description: string;
+          starting_point: number;
+          max_point: number;
+          image_urls: string[];
+          end_date: string;
+          address_id: string;
+          business_name: string;
+          postal_code: string;
+          road_address: string;
+          detail_address: string;
+        }[];
+      };
       get_auction_summary_with_address: {
-        Args: { auction_id_param: string }
+        Args: { auction_id_param: string };
         Returns: {
-          auction_id: string
-          title: string
-          end_date: string
-          image_urls: string[]
-          address_id: string
-          business_name: string
-          postal_code: string
-          road_address: string
-          detail_address: string
-        }[]
-      }
+          auction_id: string;
+          title: string;
+          end_date: string;
+          image_urls: string[];
+          address_id: string;
+          business_name: string;
+          postal_code: string;
+          road_address: string;
+          detail_address: string;
+        }[];
+      };
       set_winning_bid: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
-    }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    : never = never
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
+  DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums'] | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    : never = never
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    : never = never
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
 
 export const Constants = {
   graphql_public: {
-    Enums: {},
+    Enums: {}
   },
   public: {
-    Enums: {},
-  },
-} as const
+    Enums: {}
+  }
+} as const;


### PR DESCRIPTION
## 📌 관련 이슈
  closes #165 

## Task TODOLIST

- [X] 입찰 참여자일 경우, 경매 현황의 경매 등록 버튼을 클릭하면 마이 페이지로 이동
- [X] 주소 등록이 안 되어있을 경우, 경매 등록 버튼 클릭 시 주소 등록 페이지로 이동
- [X] 경매 등록 중일 경우, 경매 등록 버튼 비활성화해서 경매 중복 등록 방지
- [X] 경매 현황에서 최신 순으로 정렬할 경우, 경매가 중복으로 나오는 현상 수정

## ✨ 개발 내용
- 경매 등록 조건에 해당되지 않는 유저는 주소 등록 버튼을 클릭해도 경매 등록 페이지에 접속하지 못하게 구현

## TroubleShotting
### 경매 현황에서 최신 순으로 정렬할 경우, 경매가 중복으로 나오는 현상 수정
#### 문제
- 경매 현황에서 최신 순으로 정렬할 경우, 일부 경매가 중복으로 나옴

#### 원인
- 현재 경매 현황은 tanstack query의 useInfiniteQuery를 사용해서 무한 스크롤에 의해 경매 리스트가 출력
- useInfiniteQuery는 경매 리스트들을 페이지로 나누어서 경매들을 출력
- useInfiniteQuery로 가져오는 supabase api는 created_at 칼럼의 순서로만 출력되고 있음
- created_at이 같은 경매들끼리의 순서는 정해진 것이 없음
- 페이지로 나누어서 나열하는 과정에서 일부 경매들이 중복으로 들어감

#### 해결
- created_at으로 정렬한 다음, 경매의 고유 값인 auction_id로 다시 정렬해서 나열

#### 이점
- 경매가 중복해서 나열되는 현상 해결