### PR TITLE
1차 테스트 후, 경매 상세페이지 2차 리팩토링 #180

### DIFF
--- a/apps/web/src/entities/auth/supabase/client.ts
+++ b/apps/web/src/entities/auth/supabase/client.ts
@@ -22,6 +22,7 @@ export const selectSignUp = async (provider: Provider) => {
   }
 };
 
+//ANCHOR - 유저 역할
 export const selectUser = async (userId: string) => {
   const { data, error } = await supabase.from('users').select('*').eq('id', userId).maybeSingle();
 

--- a/apps/web/src/features/auction/AuctionDetailNavbar.tsx
+++ b/apps/web/src/features/auction/AuctionDetailNavbar.tsx
@@ -1,6 +1,5 @@
 import { getAuctionInfoWithAddress } from 'src/entities/auction/api';
 import { getServerUser } from 'src/entities/auth/serverAction';
-import { selectUser } from 'src/entities/auth/supabase/client';
 import AuctionFavoriteMarkToggle from 'src/features/auction/AuctionFavoriteMarkToggle';
 import AuctionActionButtons from 'src/features/auction/button/AuctionActionButtons';
 import { type AuctionRow } from 'src/shared/supabase/types';
@@ -18,9 +17,11 @@ const AuctionDetailNavbar = async ({ auctionId }: { auctionId: AuctionRow['aucti
     <>
       <ClientContainer>
         <nav className="absolute left-0 right-0 top-5 z-10 flex items-center justify-between">
-          <div className="bg-gray bg-(--color-background)/70 flex size-10 justify-center rounded-sm shadow-sm">
-            <GoBackButton className="-translate-x-2" />
-          </div>
+          <nav>
+            <div className="bg-gray bg-(--color-background)/70 size-10 rounded-sm shadow-sm">
+              <GoBackButton className="-translate-x-2 -translate-y-2/4" mode="push" url="/main" />
+            </div>
+          </nav>
 
           {isUser && <AuctionActionButtons auctionId={auctionInfo.auction_id} />}
           {!isUser && (

--- a/apps/web/src/features/auction/AuctionDetailNavbar.tsx
+++ b/apps/web/src/features/auction/AuctionDetailNavbar.tsx
@@ -17,11 +17,9 @@ const AuctionDetailNavbar = async ({ auctionId }: { auctionId: AuctionRow['aucti
     <>
       <ClientContainer>
         <nav className="absolute left-0 right-0 top-5 z-10 flex items-center justify-between">
-          <nav>
-            <div className="bg-gray bg-(--color-background)/70 size-10 rounded-sm shadow-sm">
-              <GoBackButton className="-translate-x-2 -translate-y-2/4" mode="push" url="/main" />
-            </div>
-          </nav>
+          <div className="bg-gray bg-(--color-background)/70 size-10 rounded-sm shadow-sm">
+            <GoBackButton className="-translate-x-2 -translate-y-2/4" mode="push" url="/main" />
+          </div>
 
           {isUser && <AuctionActionButtons auctionId={auctionInfo.auction_id} />}
           {!isUser && (

--- a/apps/web/src/features/auction/AuctionDetailNavbar.tsx
+++ b/apps/web/src/features/auction/AuctionDetailNavbar.tsx
@@ -10,12 +10,9 @@ import GoBackButton from 'src/shared/ui/GoBackButton';
 const AuctionDetailNavbar = async ({ auctionId }: { auctionId: AuctionRow['auction_id'] }) => {
   const auctionInfo = await getAuctionInfoWithAddress(auctionId); //ANCHOR - 경매 상품 및 경매 업체 정보
   const userInfo = await getServerUser();
-  const profile = await selectUser(userInfo!.id);
 
   // 현재 유저가 경매 물품의 판매자인지의 여부
   const isUser = auctionInfo.user_id === userInfo?.id;
-  // 현재 유저가 입찰 참여자(buyer)인지의 여부
-  const isBuyer = profile!.role === 'buyer';
 
   return (
     <>
@@ -26,7 +23,7 @@ const AuctionDetailNavbar = async ({ auctionId }: { auctionId: AuctionRow['aucti
           </div>
 
           {isUser && <AuctionActionButtons auctionId={auctionInfo.auction_id} />}
-          {!isUser && isBuyer && (
+          {!isUser && (
             <AuctionFavoriteMarkToggle auctionInfo={auctionInfo} auctionId={auctionId} userId={userInfo!.id} />
           )}
         </nav>

--- a/apps/web/src/features/auction/BidderRankingInfoSection.tsx
+++ b/apps/web/src/features/auction/BidderRankingInfoSection.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@repo/ui/components/ui/card';
+import { FaRankingStar } from 'react-icons/fa6';
 import { getBidderRanking } from 'src/entities/auction/api';
 import BidderRankingList from 'src/features/auction/list/components/BidderRankingList';
 import BidEmpty from 'src/features/auction/shared/BidEmpty';
@@ -11,9 +12,12 @@ const BidderRankingInfoSection = async ({ auctionId }: { auctionId: AuctionRow['
 
   return (
     <Card className="mb-4 p-5 shadow-sm">
-      <PageTitle className="font-medium" size="md" order="left">
-        입찰 랭킹 순위
-      </PageTitle>
+      <div className="mb-4 flex items-center gap-2">
+        <FaRankingStar className="text-(--color-primary) size-8" />
+        <PageTitle className="font-medium" size="md" order="left">
+          입찰 랭킹
+        </PageTitle>
+      </div>
       {isBidder ? <BidderRankingList bidderRankingList={bidderRankings} /> : <BidEmpty />}
     </Card>
   );

--- a/apps/web/src/features/auction/PopularListSection.tsx
+++ b/apps/web/src/features/auction/PopularListSection.tsx
@@ -20,7 +20,7 @@ const PopularListSection = async () => {
 
   return (
     <div className="mt-8">
-      <AuctionSectionHeader title="인기 경매" href={'/auctions?order=favorites'} />
+      <AuctionSectionHeader title="인기 경매" href={'/auctions?order=favorite_count'} />
       <div className="mb-4 flex items-center justify-between"></div>
       <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {popularAuctions.map((auction: SortedAuctionItemType) => (

--- a/apps/web/src/features/auction/SellerInfoSection.tsx
+++ b/apps/web/src/features/auction/SellerInfoSection.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@repo/ui/components/ui/card';
 import { getAuctionInfoWithAddress, getSellerAuctionCount } from 'src/entities/auction/api';
-import InquiryDrawerTrigger from 'src/features/auction/InquiryDrawerTrigger';
 import { type AuctionRow } from 'src/shared/supabase/types';
 import BaseAvatar from 'src/shared/ui/BaseAvatar';
 import ClientContainer from 'src/shared/ui/ClientContainer';
@@ -11,12 +10,9 @@ const SellerInfoSection = async ({ auctionId }: { auctionId: AuctionRow['auction
 
   return (
     <Card className="mb-4 p-5 shadow-sm">
-      <ClientContainer>
-        <div className="flex justify-between">
-          <h3 className="font-medium">판매자 정보</h3>
-          <InquiryDrawerTrigger auctionId={auctionId} />
-        </div>
-      </ClientContainer>
+      <div className="flex justify-between">
+        <h3 className="font-medium">판매자 정보</h3>
+      </div>
 
       <div className="mb-4 flex items-center gap-2">
         <ClientContainer>

--- a/apps/web/src/features/auction/SellerInfoSection.tsx
+++ b/apps/web/src/features/auction/SellerInfoSection.tsx
@@ -10,11 +10,11 @@ const SellerInfoSection = async ({ auctionId }: { auctionId: AuctionRow['auction
 
   return (
     <Card className="mb-4 p-5 shadow-sm">
-      <div className="flex justify-between">
+      <div className="mb-4 flex justify-between">
         <h3 className="font-medium">판매자 정보</h3>
       </div>
 
-      <div className="mb-4 flex items-center gap-2">
+      <div className="flex items-center gap-2">
         <ClientContainer>
           <BaseAvatar src={auctionInfo.company_image!} alt={auctionInfo.business_name!} size="sm" />
         </ClientContainer>

--- a/apps/web/src/features/auction/card/LatestAuctionCard.tsx
+++ b/apps/web/src/features/auction/card/LatestAuctionCard.tsx
@@ -36,7 +36,7 @@ const LatestAuctionCard = ({ auction }: { auction: SortedAuctionItemType }) => {
         </div>
 
         <div className="ml-2 flex-1">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <div>
               <PageDescription clamp={1}>{auction.title}</PageDescription>
             </div>

--- a/apps/web/src/features/auction/carousel/EndingSoonCarousel.tsx
+++ b/apps/web/src/features/auction/carousel/EndingSoonCarousel.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Carousel, CarouselContent, CarouselItem } from '@repo/ui/components/ui/carousel';
-import NotAuctionImage from 'src/assets/images/auctionDefault.png';
 import AuctionCard from 'src/features/auction/shared/AuctionCard';
 import type { SortedAuctionItemType } from 'src/entities/auction/types';
 
@@ -18,14 +17,11 @@ const EndingSoonCarousel = ({ endingSoonAuctions }: { endingSoonAuctions: Sorted
             <CarouselItem key={auction.auction_id} className="basis-4/5 pl-4 sm:basis-3/5">
               <AuctionCard
                 auctionId={auction.auction_id}
-                // status={auction.status}
-                imageSrc={auction.image_urls?.[0] ?? NotAuctionImage.src}
+                imageSrc={auction.image_urls[0]}
                 title={auction.title}
-                // currentPoint={auction.current_point}
                 endDate={auction.end_date}
                 episodeCount={auction.episodes?.length ?? 0}
                 favoriteCount={auction.favorites?.length ?? 0}
-                // address={auction.address_id!}
               />
             </CarouselItem>
           ))}

--- a/apps/web/src/features/auction/list/components/BidderRankingList.tsx
+++ b/apps/web/src/features/auction/list/components/BidderRankingList.tsx
@@ -8,7 +8,7 @@ import { maskEmail } from 'src/shared/utils/maskEmail';
 
 const BidderRankingList = ({ bidderRankingList }: { bidderRankingList: BidderRankingInfoType[] }) => {
   return (
-    <ul>
+    <ul className="space-y-4">
       {bidderRankingList.map((bidder, index) => (
         <li key={`${bidder.users.id}${index}`} className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/apps/web/src/features/auction/shared/AuctionCard.tsx
+++ b/apps/web/src/features/auction/shared/AuctionCard.tsx
@@ -32,7 +32,7 @@ const AuctionCard = ({ auctionId, imageSrc, title, endDate, favoriteCount, episo
                 src={noAuctionImage}
                 fill
                 alt={`${title} 이미지`}
-                className="object-contain"
+                className="translate-y-4 object-contain"
                 sizes="(min-width: 768px) 400px, 80vw"
               />
             )}

--- a/apps/web/src/features/auction/shared/AuctionCard.tsx
+++ b/apps/web/src/features/auction/shared/AuctionCard.tsx
@@ -18,7 +18,7 @@ const AuctionCard = ({ auctionId, imageSrc, title, endDate, favoriteCount, episo
     <li className="rounded-button hover:scale-98 active:scale-96 overflow-hidden rounded-xl bg-white shadow-sm transition-transform">
       <Link href={`/auctions/${auctionId}`} prefetch={true}>
         <div className="relative">
-          <div className="relative h-40 w-full">
+          <div className="relative h-44 w-full">
             {imageSrc ? (
               <Image
                 src={imageSrc}
@@ -28,7 +28,13 @@ const AuctionCard = ({ auctionId, imageSrc, title, endDate, favoriteCount, episo
                 sizes="(min-width: 768px) 400px, 100vw"
               />
             ) : (
-              <Image src={noAuctionImage} fill={true} alt={`${title} 이미지`} className="object-fill object-top" />
+              <Image
+                src={noAuctionImage}
+                fill
+                alt={`${title} 이미지`}
+                className="object-contain"
+                sizes="(min-width: 768px) 400px, 80vw"
+              />
             )}
           </div>
           <Badge

--- a/apps/web/src/features/episode/EpisodePage.tsx
+++ b/apps/web/src/features/episode/EpisodePage.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import { FaRegLightbulb } from 'react-icons/fa';
 import { getAuctionSummaryInfoWithAddress } from 'src/entities/auction/api';
 import { getEpisodeInfo } from 'src/entities/episode/api';
 import { EPISODE_TIP } from 'src/entities/episode/constants';
@@ -38,8 +39,9 @@ const EpisodePage = async ({ params }: { params: Promise<{ id: string[] }> }) =>
         <AuctionSummaryCard auctionInfo={auctionInfo} />
         <EpisodesForm auctionId={auctionId!} initialEpisodeInfo={initialEpisodeInfo} userId={user.id}>
           <div className="bg-(--color-secondary) my-10 rounded-lg p-4">
-            <h3 className="text-(--color-accent) mb-4 text-sm font-medium">
-              <i className="fas fa-lightbulb mr-2"></i>좋은 사연을 위한 팁
+            <h3 className="text-(--color-accent) mb-4 flex items-center gap-1 text-sm font-medium">
+              <FaRegLightbulb />
+              좋은 사연을 위한 팁
             </h3>
             <ul className="text-(--color-warm-gray) space-y-2 text-sm">
               {EPISODE_TIP.map((text, index) => (

--- a/apps/web/src/features/episode/button/EpisodeWriteButton.tsx
+++ b/apps/web/src/features/episode/button/EpisodeWriteButton.tsx
@@ -12,14 +12,18 @@ const EpisodeWriteButton = ({
   isWritten: boolean;
   className?: string;
 }) => {
+  const buttonProps = {
+    variant: 'active' as const,
+    size: 'lg' as const,
+    className: twMerge('w-full hover:bg-(--color-primary)', className)
+  };
+
   return isWritten ? (
-    // 사연이 이미 작성된 경우: '사연 작성 완료' 비활성 버튼 표시
-    <Button variant="inActive" size="lg" disabled className={twMerge('w-full', className)}>
+    <Button {...buttonProps} disabled>
       사연 작성 완료
     </Button>
   ) : (
-    // 사연을 아직 작성하지 않은 경우: '사연 작성하기' 링크 버튼 표시
-    <Button asChild variant="inActive" size="lg" className={twMerge('w-full', className)}>
+    <Button {...buttonProps} asChild>
       <Link href={`/episode/${auctionId}`}>사연 작성하기</Link>
     </Button>
   );

--- a/apps/web/src/features/episode/form/EpisodeBidModalForm.tsx
+++ b/apps/web/src/features/episode/form/EpisodeBidModalForm.tsx
@@ -109,7 +109,7 @@ const EpisodeBidModalForm = ({
 
         <div className="flex space-x-3">
           <Button
-            className="!rounded-button bg-(--color-secondary) text-(--color-text-base) hover:bg-(--color-warm-gray) flex-1"
+            className="!rounded-button bg-(--color-secondary) text-(--color-text-base) hover:bg-(--color-secondary)/60 flex-1"
             onClick={onClose}
             type="button"
           >

--- a/apps/web/src/features/episode/form/EpisodeForm.tsx
+++ b/apps/web/src/features/episode/form/EpisodeForm.tsx
@@ -67,7 +67,7 @@ const EpisodeForm = ({
         queryClient.invalidateQueries({
           queryKey: [AUCTION_BID_POINT_AMOUNT, auctionId]
         });
-        router.push(`/auctions/${auctionId}`);
+        router.replace(`/auctions/${auctionId}`);
         toast.success(message);
       }
     } catch (error) {

--- a/apps/web/src/features/episode/modal/EpisodeBidModal.tsx
+++ b/apps/web/src/features/episode/modal/EpisodeBidModal.tsx
@@ -89,7 +89,8 @@ const EpisodeBidModal = ({ episode }: { episode: EpisodeItemProps }) => {
             onClick={() => {
               setOpen(true);
             }}
-            variant="inActive"
+            variant="active"
+            className="hover:bg-(--color-primary)"
           />
         </DialogTrigger>
 

--- a/apps/web/src/features/episode/skeleton/EpisodeCardSkeleton.tsx
+++ b/apps/web/src/features/episode/skeleton/EpisodeCardSkeleton.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from '@repo/ui/components/ui/skeleton';
+
+const EpisodeCardSkeleton = () => {
+  return (
+    <div>
+      <div className="flex justify-between">
+        <div className="flex items-center gap-2 py-4">
+          <Skeleton className="size-10 rounded-full" />
+          <div className="space-y-2">
+            <div className="flex items-center gap-1">
+              <Skeleton className="h-3 w-9" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+            <Skeleton className="h-3 w-28" />
+          </div>
+        </div>
+        <div className="flex flex-col items-end justify-center"></div>
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-full" />
+        <Skeleton className="h-4 w-full" />
+      </div>
+      <div className="flex items-center justify-between py-4">
+        <Skeleton className="h-4 w-9" />
+      </div>
+    </div>
+  );
+};
+
+export default EpisodeCardSkeleton;

--- a/apps/web/src/shared/ui/FormActionButton.tsx
+++ b/apps/web/src/shared/ui/FormActionButton.tsx
@@ -5,14 +5,26 @@ type FormActionsButtonType = {
   buttonLabel: string;
   isSubmitting: boolean;
   isRedirecting: boolean;
+
   className?: string;
 };
 
-const FormActionButton = ({ buttonLabel, isRedirecting, isSubmitting, className }: FormActionsButtonType) => {
+const FormActionButton = ({
+  buttonLabel,
+  isRedirecting,
+  isSubmitting,
+
+  className
+}: FormActionsButtonType) => {
   return (
     <>
       <div className={twMerge(`absolute bottom-2 left-0 right-0 flex justify-end space-x-2 px-5 ${className}`)}>
-        <Button variant="inActive" type="submit" className="h-12 flex-1" disabled={isSubmitting || isRedirecting}>
+        <Button
+          variant="active"
+          type="submit"
+          className="hover:bg-(--color-primary) h-12 flex-1"
+          disabled={isSubmitting || isRedirecting}
+        >
           {buttonLabel}
         </Button>
       </div>

--- a/apps/web/src/shared/ui/GoBackButton.tsx
+++ b/apps/web/src/shared/ui/GoBackButton.tsx
@@ -2,15 +2,25 @@
 import { useRouter } from 'next/navigation';
 import { FaArrowLeft } from 'react-icons/fa6';
 
-const GoBackButton = ({ className }: { className?: string }) => {
+//NOTE - 공통 타입으로 지정
+interface GoBackButtonProps {
+  className?: string;
+  mode?: 'push' | 'back';
+  url?: string;
+}
+
+const GoBackButton = ({ className, mode = 'back', url = '' }: GoBackButtonProps) => {
   const router = useRouter();
 
   const handleGoBack = () => {
-    router.back();
+    if (mode === 'back') {
+      router.back();
+    }
+    router.push(url);
   };
 
   return (
-    <button onClick={handleGoBack} className={`absolute left-5 top-2/4 -translate-y-2/4 ${className}`}>
+    <button onClick={handleGoBack} className={`absolute left-5 top-2/4 ${className}`}>
       <FaArrowLeft className="hover:text-(--color-accent) size-4" />
     </button>
   );

--- a/apps/web/src/shared/utils/formatRemainingTime.ts
+++ b/apps/web/src/shared/utils/formatRemainingTime.ts
@@ -13,7 +13,7 @@ type RemainingTimeType = {
 export const formatRemainingTime = (endDate: string): RemainingTimeType => {
   const now = new TZDate(new Date(), 'Asia/Seoul');
   const end = new TZDate(endDate, 'Asia/Seoul');
-  let status: AuctionTimerStatus;
+  let status: AuctionTimerStatus = 'ongoing';
   let remainTime = '';
 
   const duration = intervalToDuration({ start: now, end });
@@ -23,13 +23,6 @@ export const formatRemainingTime = (endDate: string): RemainingTimeType => {
     format: ['days', 'hours', 'minutes'],
     locale: ko
   });
-
-  //ANCHOR - status: 상태에 따라 시간 color 변경
-  if (duration.days! <= 0 && duration.hours! <= 0) {
-    status = 'urgent';
-  } else {
-    status = 'ongoing';
-  }
 
   //ANCHOR - 일부 남은 시간을 표시(메인 페이지의 뱃지)
   switch (true) {
@@ -45,11 +38,16 @@ export const formatRemainingTime = (endDate: string): RemainingTimeType => {
       remainTime = `${duration.days}일 남음`;
       break;
 
-    case (duration.hours ?? 0) > 0:
+    case (duration.hours ?? 0) > 1:
       remainTime = `${duration.hours}시간 남음`;
       break;
 
+    case (duration.hours ?? 0) === 1:
+      status = 'urgent';
+      remainTime = `${duration.hours}시간 남음`;
+      break;
     case (duration.minutes ?? 0) > 0:
+      status = 'urgent';
       remainTime = `${duration.minutes}분 남음`;
       break;
 


### PR DESCRIPTION
## 📌 관련 이슈
  closes #180 

## Task TODOLIST
- [x] - 북마크 조건부 표시
    - true: 입찰 참여자 및 경매 판매자까지  
    - false: 경매 물품 등록자인 경매 판매자

- [ ]  사연 등록 시 -> 에러페이지 -> 다시시도 버튼 클릭 -> 등록된 사연 보임  에러 수정
- [x] 사연 등록 후, 뒤로가기 클릭 시  등록페이지로 이동 에러 수정
- [ ] 경매 상세페이지에서 문의하기 UI 제거
- [ ] 사연 등록 후, 뒤로가기 클릭 시  등록페이지로 이동 에러 수정
- [ ] 메인 페이지의 "인기 경매" 섹션에서 더보기 버튼 클릭 시 리스트 페이지의 "곧 경매 마감" 카테고리로 정렬
- [ ] 사연 등록 및 입찰하기 버튼 색상 변경